### PR TITLE
feat: change setInterval to request animation frame

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -64,7 +64,7 @@ export default {
     height: 80vh;
     padding: 70px;
     > * {
-      text-shadow: 0px 5px 0px #860c4e;
+      text-shadow: 1px 5px 0px #860c4e;
     }
     h1 {
       max-width: 400px;

--- a/src/components/Clock.vue
+++ b/src/components/Clock.vue
@@ -9,41 +9,50 @@ export default {
     return {
       minutes: 0,
       seconds: 0,
-      interval: null
+      animationId: null,
+      lastTime: 0,
     };
   },
   mounted() {
     const urlParams = new URLSearchParams(location.search);
     const urlMinutes = urlParams.get("minutes");
     this.minutes = Number(urlMinutes) || 10;
-    this.interval = setInterval(this.countDown, 1000);
+    this.animationId = window.requestAnimationFrame(this.countDown);
   },
   methods: {
-    countDown() {
-      // Se minutos e segundos chegaram ao zero, retorna.
-      if (this.minutes == 0 && this.seconds == 0) {
-        return clearInterval(this.interval);
+    countDown(timestamp) {
+      // Se o tempo atual (timestamp) - o último tempo considerado for menor que 1s, fazemos um "continue no loop"
+      if (timestamp - this.lastTime < 1000) {
+        this.animationId = window.requestAnimationFrame(this.countDown);
+        return null;
       }
+
+      // Se minutos e segundos chegaram ao zero, paramos o "loop"
+      if (this.minutes === 0 && this.seconds === 0) {
+        return window.cancelAnimationFrame(this.animationId);
+      }
+
+      this.lastTime = timestamp;
+
       // Controla os segundos
-      if (this.seconds == 0) {
+      if (this.seconds <= 0) {
         this.seconds = 59;
         this.minutes--;
       } else {
         this.seconds--;
       }
+
+      this.animationId = window.requestAnimationFrame(this.countDown);
     },
-    format(number) {
-      return number < 10 ? `0${number}` : number;
-    }
   },
   computed: {
     formattedMinutes() {
-      return this.format(this.minutes)
+      return String(this.minutes).padStart(2, "0");
     },
     formattedSeconds() {
-      return this.format(this.seconds)
+      return String(this.seconds).padStart(2, "0");
     },
-  }
+  },
 };
 </script>
 <style lang="scss" scoped>


### PR DESCRIPTION
Este PR foi feito para modificar duas features do relógio, uma é a adição da função nativa do Javascript, o padStart, para fazer o complemento do `0` no número em vez de fazer a verificação se ele é menor que 10. A outra é a adição do window.requestAnimationFrame, uma forma mais performática para trabalhar com mudanças de tempo no javascript em substituição do setInterval.

Por padrão o requestAnimationFrame trabalha a uma taxa de atualização dependente do tempo para execução de sua callback, na maioria das vezes a utilização dele é para executar algo em medida de FPS, no caso "os 60fps desejados por todos", porém, fiz uma modificação para alcançar os incríveis 1fps necessários para uma aplicação de relógio.

Também adicionei um pequeno offset à direita na sombra dos textos, acho que ficou mais legível.